### PR TITLE
Block Googleplus comments

### DIFF
--- a/mute.txt
+++ b/mute.txt
@@ -138,3 +138,4 @@ imgur.com##div#under-image
 ##div.discussionContainer
 ###liste_reactions
 ~nexusmods.com##.comment-thread
+###gpluscomments


### PR DESCRIPTION
One of the test urls - http://googleblog.blogspot.com/2013/05/capturing-beauty-and-wonder-of.html - which automatically redirects to http://googleblog.blogspot.co.uk/2013/05/capturing-beauty-and-wonder-of.html - does not have its comments blocked.

This addition blocks all Google+ comment sections, but does not appear to affect Google+ in any way.
